### PR TITLE
デプロイ時のWebアプリ設定がリセットされる問題を修正

### DIFF
--- a/appsscript.json
+++ b/appsscript.json
@@ -4,7 +4,7 @@
   "exceptionLogging": "STACKDRIVER",
   "runtimeVersion": "V8",
   "webapp": {
-    "access": "ANYONE",
-    "executeAs": "USER_ACCESSING"
+    "access": "ANYONE_ANONYMOUS",
+    "executeAs": "USER_DEPLOYING"
   }
 }


### PR DESCRIPTION
- appsscript.json: オーナー用設定に変更（USER_DEPLOYING + ANYONE_ANONYMOUS）
- deploy.js: スタッフ用デプロイ時にマニフェストを一時的にスタッフ設定 （USER_DEPLOYING + ANYONE）に切り替えてプッシュ・デプロイし、 完了後にオーナー設定に戻す仕組みを追加

https://claude.ai/code/session_012dresUv1SYkGt4XJCJayXT